### PR TITLE
Caliban loading in admin

### DIFF
--- a/includes/class-caliban.php
+++ b/includes/class-caliban.php
@@ -78,9 +78,12 @@ class Caliban_WP {
 
 		$this->load_dependencies();
 		$this->set_locale();
-		$this->define_admin_hooks();
-		$this->define_public_hooks();
 
+		if (\is_admin()) {
+			$this->define_admin_hooks();
+		} else {
+			$this->define_public_hooks();
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Changed the hooks to only run admin hooks in wp-admin and front hooks on the public website